### PR TITLE
Implement training completion endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ cp .env.example .env
 See [outlier_protocol](https://github.com/outlierClassifier/outlier_protocol) for detailed API specifications.
 The orchestrator also exposes `/api/train/raw` for uploading sensor text files directly. Use a `multipart/form-data` request where each file field is named `dischargeN` (starting from `discharge0`). A JSON `metadata` field specifies discharge ids and anomaly times. The backend parses the files and starts the training session using the outlier node protocol.
 
+Training nodes should POST the final training summary to `/api/trainingCompleted` once a session finishes.
+
 ## Developed with
 
 * [Node.js](https://nodejs.org/) - JavaScript runtime environment

--- a/src/controllers/orchestrator.controller.js
+++ b/src/controllers/orchestrator.controller.js
@@ -152,6 +152,31 @@ class OrchestratorController {
   }
 
   /**
+   * Recibe el resumen de entrenamiento de un nodo
+   * @param {Request} req
+   * @param {Response} res
+   */
+  async trainingCompleted(req, res) {
+    try {
+      const data = req.body;
+
+      if (!data || !data.status) {
+        return res.status(StatusCodes.BAD_REQUEST).json({
+          error: 'Formato de TrainingResponse inválido'
+        });
+      }
+
+      const entry = orchestratorService.handleTrainingCompleted(data);
+      return res.status(StatusCodes.OK).json({ message: 'Training summary stored', entry });
+    } catch (error) {
+      logger.error(`Error en trainingCompleted: ${error.message}`);
+      return res.status(StatusCodes.INTERNAL_SERVER_ERROR).json({
+        error: error.message
+      });
+    }
+  }
+
+  /**
    * Obtiene el estado de salud de los modelos
    * @param {Request} req - Objeto de solicitud HTTP
    * @param {Response} res - Objeto de respuesta HTTP

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -12,6 +12,7 @@ router.post('/predict', validatedischargealData, orchestratorController.predict)
 // Ruta para entrenamiento de modelos
 router.post('/train', validatedischargealData, orchestratorController.train);
 router.post('/train/raw', upload.any(), orchestratorController.trainRaw);
+router.post('/trainingCompleted', orchestratorController.trainingCompleted);
 
 // Ruta para verificar la salud de los servicios
 router.get('/health', orchestratorController.health);


### PR DESCRIPTION
## Summary
- store training summaries in the service
- add `trainingCompleted` controller method
- expose `/trainingCompleted` route
- document new route in README

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6856ee838a288328b67468cd8aeb7f9d