### PR TITLE
Implement batched training to prevent memory overload

### DIFF
--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -2364,59 +2364,57 @@
             });
 
             // Event listener for processing discharges for training
-            document.getElementById('processDischargesBtn').addEventListener('click', function () {
+            document.getElementById('processDischargesBtn').addEventListener('click', async function () {
                 try {
-                    const metadata = {
-                        discharges: discharges.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
-                    };
+                    const totalDischarges = discharges.length;
+                    const batchSize = 10;
+                    let batchIndex = 0;
+                    let firstResult = null;
 
-                    const formData = new FormData();
-                    formData.append('metadata', JSON.stringify(metadata));
+                    while (discharges.length > 0) {
+                        const batch = discharges.splice(0, batchSize);
+                        const metadata = {
+                            totalDischarges,
+                            batch: batchIndex,
+                            discharges: batch.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
+                        };
 
-                    discharges.forEach((discharge, idx) => {
-                        discharge.files.forEach(f => {
-                            formData.append(`discharge${idx}`, f.file, f.name);
+                        const formData = new FormData();
+                        formData.append('metadata', JSON.stringify(metadata));
+
+                        batch.forEach((discharge, idx) => {
+                            discharge.files.forEach(f => {
+                                formData.append(`discharge${idx}`, f.file, f.name);
+                            });
                         });
-                    });
 
-                    fetch('/api/train/raw', {
-                        method: 'POST',
-                        body: formData
-                    })
-                        .then(response => response.json())
-                        .then(result => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
-
-                            if (result.error) {
-                                document.getElementById('trainingResult').className = 'alert alert-danger';
-                                document.getElementById('trainingResult').innerHTML = `Error: ${result.error}`;
-                            } else {
-                                document.getElementById('trainingResult').className = 'alert alert-success';
-                                document.getElementById('trainingResult').innerHTML = `
-                                <h5>Entrenamiento iniciado</h5>
-                                <p>${result.message}</p>
-                                <p>Modelos exitosos: ${result.details.successful}</p>
-                                <p>Modelos fallidos: ${result.details.failed}</p>
-                                <p>Consulte los logs para más detalles.</p>
-                            `;
-                            }
-                        })
-                        .catch(error => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
-                            document.getElementById('trainingResult').className = 'alert alert-danger';
-                            document.getElementById('trainingResult').innerHTML = `Error sending training data: ${error.message}`;
+                        const response = await fetch('/api/train/raw', {
+                            method: 'POST',
+                            body: formData
                         });
+                        const result = await response.json();
+                        if (batchIndex === 0) {
+                            firstResult = result;
+                        }
+
+                        batchIndex++;
+                    }
 
                     document.getElementById('trainingResultContainer').style.display = 'block';
-                    document.getElementById('trainingResult').innerHTML = `
-                        <div class="text-center">
-                            <div class="spinner-border text-primary" role="status">
-                                <span class="visually-hidden">Loading...</span>
-                            </div>
-                            <p class="mt-2">Sending training data...</p>
-                        </div>
-                    `;
-                    document.getElementById('trainingResult').className = 'alert';
+                    const result = firstResult || {};
+                    if (result.error) {
+                        document.getElementById('trainingResult').className = 'alert alert-danger';
+                        document.getElementById('trainingResult').innerHTML = `Error: ${result.error}`;
+                    } else {
+                        document.getElementById('trainingResult').className = 'alert alert-success';
+                        document.getElementById('trainingResult').innerHTML = `
+                                <h5>Entrenamiento iniciado</h5>
+                                <p>${result.message || ''}</p>
+                                <p>Modelos exitosos: ${result.details ? result.details.successful : 0}</p>
+                                <p>Modelos fallidos: ${result.details ? result.details.failed : 0}</p>
+                                <p>Consulte los logs para más detalles.</p>
+                            `;
+                    }
                 } catch (error) {
                     document.getElementById('trainingResultContainer').style.display = 'block';
                     document.getElementById('trainingResult').innerHTML = `Error: ${error.message}`;

--- a/test/batch-training.test.js
+++ b/test/batch-training.test.js
@@ -1,0 +1,39 @@
+const orchestratorService = require('../src/services/orchestrator.service');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('batch training session', () => {
+  beforeEach(() => {
+    axios.mockClear();
+    orchestratorService.models = {
+      test: { enabled: true, trainingUrl: 'http://localhost:9999/train' }
+    };
+  });
+
+  afterEach(() => {
+    orchestratorService.models = {};
+    orchestratorService.trainingSession = null;
+  });
+
+  test('sends discharges across multiple batches maintaining order', async () => {
+    axios.mockResolvedValue({ data: { expectedDischarges: 4 } });
+
+    await orchestratorService.startTrainingSession(4);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd1', signals: [{ values: [1] }], times: [0], length: 1 },
+      { id: 'd2', signals: [{ values: [2] }], times: [0], length: 1 }
+    ]);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd3', signals: [{ values: [3] }], times: [0], length: 1 },
+      { id: 'd4', signals: [{ values: [4] }], times: [0], length: 1 }
+    ]);
+
+    expect(axios).toHaveBeenCalledTimes(5);
+    expect(axios.mock.calls[0][0].url).toBe('http://localhost:9999/train');
+    expect(axios.mock.calls[1][0].url).toBe('http://localhost:9999/train/1');
+    expect(axios.mock.calls[2][0].url).toBe('http://localhost:9999/train/2');
+    expect(axios.mock.calls[3][0].url).toBe('http://localhost:9999/train/3');
+    expect(axios.mock.calls[4][0].url).toBe('http://localhost:9999/train/4');
+  });
+});


### PR DESCRIPTION
## Summary
- Stream training data to models using batches to avoid accumulating all discharges in memory
- Update raw training endpoint and dashboard to send discharges in batches of 10
- Add unit test covering multi-batch training flow

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_6891253bfd948328b154fc080ca2f937