### PR TITLE
feat: stream training discharges in batches

### DIFF
--- a/src/controllers/orchestrator.controller.js
+++ b/src/controllers/orchestrator.controller.js
@@ -75,14 +75,23 @@ class OrchestratorController {
       }
       
       logger.info(`Recibida petición de entrenamiento con ${trainingData.discharges.length} descargas`);
-      
+
       try {
-        // Enviar datos de entrenamiento a todos los modelos
-        const result = await orchestratorService.trainModels(trainingData);
-        
+        let summary;
+        if (!orchestratorService.trainingSession) {
+          const total = trainingData.totalDischarges || trainingData.discharges.length;
+          summary = await orchestratorService.startTrainingSession(total);
+        }
+        await orchestratorService.sendTrainingBatch(trainingData.discharges);
+
+        if (orchestratorService.trainingSession &&
+            orchestratorService.trainingSession.enqueued >= orchestratorService.trainingSession.totalDischarges) {
+          orchestratorService.finishTraining();
+        }
+
         return res.status(StatusCodes.OK).json({
-          message: 'Entrenamiento iniciado correctamente',
-          details: result
+          message: 'Entrenamiento batch procesado correctamente',
+          details: summary
         });
       } catch (error) {
         logger.error(`Error al enviar datos a modelos: ${error.message}`);
@@ -134,11 +143,22 @@ class OrchestratorController {
         }
       }
 
-      const result = await orchestratorService.trainModels({ discharges });
+      let summary;
+      if (!orchestratorService.trainingSession) {
+        const total = meta.totalDischarges || discharges.length;
+        summary = await orchestratorService.startTrainingSession(total);
+      }
+
+      await orchestratorService.sendTrainingBatch(discharges);
+
+      if (orchestratorService.trainingSession &&
+          orchestratorService.trainingSession.enqueued >= orchestratorService.trainingSession.totalDischarges) {
+        orchestratorService.finishTraining();
+      }
 
       return res.status(StatusCodes.OK).json({
-        message: 'Entrenamiento iniciado correctamente',
-        details: result
+        message: 'Entrenamiento batch procesado correctamente',
+        details: summary
       });
     } catch (error) {
       logger.error(`Error en entrenamiento raw: ${error.message}`);

--- a/src/services/orchestrator.service.js
+++ b/src/services/orchestrator.service.js
@@ -13,6 +13,8 @@ class OrchestratorService {
     this.trainingTimeout = config.timeouts.training;
     // In-memory storage for training results
     this.trainingSummaries = [];
+    // Estado de entrenamiento actual para manejo por lotes
+    this.trainingSession = null;
   }
 
   /**
@@ -126,6 +128,166 @@ class OrchestratorService {
   }
 
   /**
+   * Inicia una sesión de entrenamiento con todos los modelos habilitados
+   * y almacena el estado para el envío por lotes.
+   * @param {number} totalDischarges - Total de descargas a enviar en toda la sesión
+   * @returns {Object} Resumen de los modelos que aceptaron el entrenamiento
+   */
+  async startTrainingSession(totalDischarges) {
+    const enabledModels = Object.keys(this.models)
+      .filter(model => this.models[model].enabled);
+
+    logger.info(`Enabled models for training: ${enabledModels.join(', ')}`);
+
+    if (enabledModels.length === 0) {
+      logger.error('No models are enabled');
+      throw new Error('No models are enabled for training');
+    }
+
+    const timeoutSeconds = Math.ceil(this.trainingTimeout / 1000);
+    const sessionModels = {};
+    const details = [];
+    let successful = 0;
+
+    for (const modelName of enabledModels) {
+      const modelConfig = this.models[modelName];
+      try {
+        await axios({
+          method: 'post',
+          url: modelConfig.trainingUrl,
+          data: { totalDischarges, timeoutSeconds },
+          timeout: this.trainingTimeout
+        });
+        sessionModels[modelName] = { trainingUrl: modelConfig.trainingUrl, queue: [], nextSeq: 1, sending: false };
+        details.push({ modelName, status: 'success' });
+        successful += 1;
+      } catch (error) {
+        logger.error(`Error starting training for ${modelName}: ${error.message}`);
+        details.push({ modelName, status: 'error', error: error.message });
+      }
+    }
+
+    this.trainingSession = {
+      totalDischarges,
+      enqueued: 0,
+      finished: false,
+      models: sessionModels
+    };
+
+    return {
+      successful,
+      failed: details.length - successful,
+      details
+    };
+  }
+
+  /**
+   * Envía un lote de descargas a los modelos dentro de la sesión activa
+   * @param {Array<Object>} rawDischarges - Descargas del lote
+   */
+  async sendTrainingBatch(rawDischarges = []) {
+    if (!this.trainingSession) {
+      throw new Error('No training session started');
+    }
+
+    const stream = this.prepareTrainingStream(rawDischarges);
+
+    for await (const discharge of stream) {
+      for (const modelName of Object.keys(this.trainingSession.models)) {
+        const model = this.trainingSession.models[modelName];
+        model.queue.push(this.cloneDischarge(discharge));
+        this.processQueue(modelName);
+      }
+
+      if (discharge.signals) {
+        for (const s of discharge.signals) {
+          s.values = null;
+        }
+        discharge.signals = null;
+      }
+      discharge.times = null;
+
+      this.trainingSession.enqueued += 1;
+    }
+  }
+
+  /**
+   * Finaliza la sesión de entrenamiento actual
+   */
+  finishTraining() {
+    if (this.trainingSession) {
+      this.trainingSession.finished = true;
+      if (this.allQueuesEmpty()) {
+        this.trainingSession = null;
+      }
+    }
+  }
+
+  allQueuesEmpty() {
+    return Object.values(this.trainingSession.models)
+      .every(m => m.queue.length === 0 && !m.sending);
+  }
+
+  cloneDischarge(d) {
+    const clone = { id: d.id, length: d.length };
+    if (d.anomalyTime !== undefined) {
+      clone.anomalyTime = d.anomalyTime;
+    }
+    if (d.signals) {
+      clone.signals = d.signals.map(s => ({ ...s, values: [...s.values] }));
+    }
+    if (d.times) {
+      clone.times = [...d.times];
+    }
+    return clone;
+  }
+
+  async processQueue(modelName) {
+    const model = this.trainingSession.models[modelName];
+    if (model.sending) return;
+    model.sending = true;
+
+    while (model.queue.length > 0) {
+      const discharge = model.queue[0];
+      let sent = false;
+      while (!sent) {
+        try {
+          await axios({
+            method: 'post',
+            url: `${model.trainingUrl}/${model.nextSeq}`,
+            data: discharge,
+            timeout: this.trainingTimeout
+          });
+          sent = true;
+        } catch (error) {
+          if (!error.response) {
+            await new Promise(resolve => setTimeout(resolve, 500));
+          } else {
+            logger.error(`Error training ${modelName}: ${error.message}`);
+            sent = true;
+          }
+        }
+      }
+
+      if (discharge.signals) {
+        for (const s of discharge.signals) {
+          s.values = null;
+        }
+        discharge.signals = null;
+      }
+      discharge.times = null;
+
+      model.queue.shift();
+      model.nextSeq += 1;
+    }
+
+    model.sending = false;
+    if (this.trainingSession.finished && this.allQueuesEmpty()) {
+      this.trainingSession = null;
+    }
+  }
+
+  /**
    * Distribuye los datos a todos los modelos habilitados
    * @param {Object} data - Datos para la predicción (formato discharges)
    * @returns {Promise<Object>} - Resultados de todos los modelos y votación final
@@ -177,44 +339,22 @@ class OrchestratorService {
    */
   async trainModels(data) {
     logger.info('Starting training process for all models');
-    
+
     // Validar formato de datos
     if (!data.discharges || !Array.isArray(data.discharges)) {
       logger.error('Formato de datos inválido: se espera un objeto con array "discharges"');
       throw new Error('Formato de datos inválido: se espera un objeto con array "discharges"');
     }
-    
-    logger.info(`Procesando entrenamiento con ${data.discharges.length} descargas`);
-    
-    const enabledModels = Object.keys(this.models)
-      .filter(model => this.models[model].enabled);
-    
-    logger.info(`Enabled models for training: ${enabledModels.join(', ')}`);
-    
-    if (enabledModels.length === 0) {
-      logger.error('No models are enabled');
-      throw new Error('No models are enabled for training');
-    }
-    
-    const totalDischarges = data.discharges.length;
 
-    // Llamadas en paralelo a todos los modelos para entrenamiento
-    const trainingPromises = enabledModels.map(model => {
-      const stream = this.prepareTrainingStream(data.discharges);
-      return this.trainModel(model, stream, totalDischarges);
-    });
-    
-    // Esperar todas las respuestas
-    const responses = await Promise.all(trainingPromises);
-    
-    const summary = {
-      successful: responses.filter(r => r.status === 'success').length,
-      failed: responses.filter(r => r.status === 'error').length,
-      details: responses
-    };
-    
+    logger.info(`Procesando entrenamiento con ${data.discharges.length} descargas`);
+
+    const totalDischarges = data.discharges.length;
+    const summary = await this.startTrainingSession(totalDischarges);
+    await this.sendTrainingBatch(data.discharges);
+    this.finishTraining();
+
     logger.info(`Training completed: ${summary.successful} successful, ${summary.failed} failed`);
-    
+
     return summary;
   }
 

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -2364,63 +2364,72 @@
             });
 
             // Event listener for processing discharges for training
-            document.getElementById('processDischargesBtn').addEventListener('click', function () {
+            document.getElementById('processDischargesBtn').addEventListener('click', async function () {
+                const btn = document.getElementById('processDischargesBtn');
+                const original = btn.innerHTML;
+                btn.disabled = true;
+                btn.innerHTML = '<span class="spinner-border spinner-border-sm" role="status" aria-hidden="true"></span> Processing...';
+
                 try {
-                    const metadata = {
-                        discharges: discharges.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
-                    };
+                    const total = discharges.length;
+                    let firstResult = null;
 
-                    const formData = new FormData();
-                    formData.append('metadata', JSON.stringify(metadata));
+                    for (let start = 0; start < discharges.length; start += 10) {
+                        const batch = discharges.slice(start, start + 10);
+                        const metadata = {
+                            totalDischarges: total,
+                            discharges: batch.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
+                        };
 
-                    discharges.forEach((discharge, idx) => {
-                        discharge.files.forEach(f => {
-                            formData.append(`discharge${idx}`, f.file, f.name);
+                        const formData = new FormData();
+                        formData.append('metadata', JSON.stringify(metadata));
+
+                        batch.forEach((discharge, idx) => {
+                            discharge.files.forEach(f => {
+                                formData.append(`discharge${idx}`, f.file, f.name);
+                            });
                         });
-                    });
 
-                    fetch('/api/train/raw', {
-                        method: 'POST',
-                        body: formData
-                    })
-                        .then(response => response.json())
-                        .then(result => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
+                        let response;
+                        while (true) {
+                            try {
+                                response = await fetch('/api/train/raw', {
+                                    method: 'POST',
+                                    body: formData
+                                });
+                                break;
+                            } catch (err) {
+                                await new Promise(r => setTimeout(r, 500));
+                            }
+                        }
+                        const result = await response.json();
+                        if (!firstResult) {
+                            firstResult = result;
+                        }
+                    }
 
-                            if (result.error) {
-                                document.getElementById('trainingResult').className = 'alert alert-danger';
-                                document.getElementById('trainingResult').innerHTML = `Error: ${result.error}`;
-                            } else {
-                                document.getElementById('trainingResult').className = 'alert alert-success';
-                                document.getElementById('trainingResult').innerHTML = `
+                    document.getElementById('trainingResultContainer').style.display = 'block';
+
+                    if (firstResult && firstResult.error) {
+                        document.getElementById('trainingResult').className = 'alert alert-danger';
+                        document.getElementById('trainingResult').innerHTML = `Error: ${firstResult.error}`;
+                    } else if (firstResult) {
+                        document.getElementById('trainingResult').className = 'alert alert-success';
+                        document.getElementById('trainingResult').innerHTML = `
                                 <h5>Entrenamiento iniciado</h5>
-                                <p>${result.message}</p>
-                                <p>Modelos exitosos: ${result.details.successful}</p>
-                                <p>Modelos fallidos: ${result.details.failed}</p>
+                                <p>${firstResult.message}</p>
+                        ${firstResult.details ? `<p>Modelos exitosos: ${firstResult.details.successful}</p>
+                                <p>Modelos fallidos: ${firstResult.details.failed}</p>` : ''}
                                 <p>Consulte los logs para más detalles.</p>
                             `;
-                            }
-                        })
-                        .catch(error => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
-                            document.getElementById('trainingResult').className = 'alert alert-danger';
-                            document.getElementById('trainingResult').innerHTML = `Error sending training data: ${error.message}`;
-                        });
-
-                    document.getElementById('trainingResultContainer').style.display = 'block';
-                    document.getElementById('trainingResult').innerHTML = `
-                        <div class="text-center">
-                            <div class="spinner-border text-primary" role="status">
-                                <span class="visually-hidden">Loading...</span>
-                            </div>
-                            <p class="mt-2">Sending training data...</p>
-                        </div>
-                    `;
-                    document.getElementById('trainingResult').className = 'alert';
+                    }
                 } catch (error) {
                     document.getElementById('trainingResultContainer').style.display = 'block';
-                    document.getElementById('trainingResult').innerHTML = `Error: ${error.message}`;
                     document.getElementById('trainingResult').className = 'alert alert-danger';
+                    document.getElementById('trainingResult').innerHTML = `Error: ${error.message}`;
+                } finally {
+                    btn.disabled = false;
+                    btn.innerHTML = original;
                 }
             });
 

--- a/test/batch-training.test.js
+++ b/test/batch-training.test.js
@@ -1,0 +1,40 @@
+const orchestratorService = require('../src/services/orchestrator.service');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('batch training session', () => {
+  beforeEach(() => {
+    axios.mockClear();
+    orchestratorService.models = {
+      test: {
+        enabled: true,
+        trainingUrl: 'http://localhost:9999/train'
+      }
+    };
+  });
+
+  afterEach(async () => {
+    orchestratorService.models = {};
+    orchestratorService.finishTraining();
+    await new Promise(r => setTimeout(r, 0));
+  });
+
+  test('processes multiple batches without restarting', async () => {
+    axios.mockResolvedValue({ data: { expectedDischarges: 2 } });
+
+    await orchestratorService.startTrainingSession(2);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd1', signals: [{ values: [1] }], times: [0], length: 1 }
+    ]);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd2', signals: [{ values: [2] }], times: [0], length: 1 }
+    ]);
+    await new Promise(r => setTimeout(r, 0));
+
+    expect(axios).toHaveBeenCalledTimes(3);
+    expect(axios.mock.calls[0][0].url).toBe('http://localhost:9999/train');
+    expect(axios.mock.calls[1][0].url).toBe('http://localhost:9999/train/1');
+    expect(axios.mock.calls[2][0].url).toBe('http://localhost:9999/train/2');
+  });
+});


### PR DESCRIPTION
## Summary
- manage training batches per model with individual queues and network error retries
- finalize training after all discharges are enqueued while models continue processing
- show spinner and retry on network errors during dashboard batch uploads

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891253bfd948328b154fc080ca2f937