### PR TITLE
feat: stream training discharges in batches

### DIFF
--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -1924,6 +1924,20 @@
             });
         }
 
+        async function fetchWithRetry(url, options, delay = 500) {
+            while (true) {
+                try {
+                    return await fetch(url, options);
+                } catch (error) {
+                    if (error && error.message.includes('NetworkError')) {
+                        await new Promise(res => setTimeout(res, delay));
+                        continue;
+                    }
+                    throw error;
+                }
+            }
+        }
+
         window.showPredictionDetails = function (index) {
             const prediction = predictionHistory[index];
             if (prediction) {
@@ -2364,48 +2378,10 @@
             });
 
             // Event listener for processing discharges for training
-            document.getElementById('processDischargesBtn').addEventListener('click', function () {
+            document.getElementById('processDischargesBtn').addEventListener('click', async function () {
                 try {
-                    const metadata = {
-                        discharges: discharges.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
-                    };
-
-                    const formData = new FormData();
-                    formData.append('metadata', JSON.stringify(metadata));
-
-                    discharges.forEach((discharge, idx) => {
-                        discharge.files.forEach(f => {
-                            formData.append(`discharge${idx}`, f.file, f.name);
-                        });
-                    });
-
-                    fetch('/api/train/raw', {
-                        method: 'POST',
-                        body: formData
-                    })
-                        .then(response => response.json())
-                        .then(result => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
-
-                            if (result.error) {
-                                document.getElementById('trainingResult').className = 'alert alert-danger';
-                                document.getElementById('trainingResult').innerHTML = `Error: ${result.error}`;
-                            } else {
-                                document.getElementById('trainingResult').className = 'alert alert-success';
-                                document.getElementById('trainingResult').innerHTML = `
-                                <h5>Entrenamiento iniciado</h5>
-                                <p>${result.message}</p>
-                                <p>Modelos exitosos: ${result.details.successful}</p>
-                                <p>Modelos fallidos: ${result.details.failed}</p>
-                                <p>Consulte los logs para más detalles.</p>
-                            `;
-                            }
-                        })
-                        .catch(error => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
-                            document.getElementById('trainingResult').className = 'alert alert-danger';
-                            document.getElementById('trainingResult').innerHTML = `Error sending training data: ${error.message}`;
-                        });
+                    const total = discharges.length;
+                    let firstResult = null;
 
                     document.getElementById('trainingResultContainer').style.display = 'block';
                     document.getElementById('trainingResult').innerHTML = `
@@ -2417,10 +2393,49 @@
                         </div>
                     `;
                     document.getElementById('trainingResult').className = 'alert';
+
+                    for (let start = 0; start < discharges.length; start += 10) {
+                        const batch = discharges.slice(start, start + 10);
+                        const metadata = {
+                            totalDischarges: total,
+                            discharges: batch.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
+                        };
+
+                        const formData = new FormData();
+                        formData.append('metadata', JSON.stringify(metadata));
+
+                        batch.forEach((discharge, idx) => {
+                            discharge.files.forEach(f => {
+                                formData.append(`discharge${idx}`, f.file, f.name);
+                            });
+                        });
+
+                        const response = await fetchWithRetry('/api/train/raw', {
+                            method: 'POST',
+                            body: formData
+                        });
+                        const result = await response.json();
+                        if (!firstResult) {
+                            firstResult = result;
+                        }
+                    }
+
+                    if (firstResult && firstResult.error) {
+                        document.getElementById('trainingResult').className = 'alert alert-danger';
+                        document.getElementById('trainingResult').innerHTML = `Error: ${firstResult.error}`;
+                    } else if (firstResult) {
+                        document.getElementById('trainingResult').className = 'alert alert-success';
+                        document.getElementById('trainingResult').innerHTML = `
+                                <h5>Entrenamiento iniciado</h5>
+                                <p>${firstResult.message}</p>
+                        ${firstResult.details ? `<p>Modelos exitosos: ${firstResult.details.successful}</p>
+                                <p>Modelos fallidos: ${firstResult.details.failed}</p>` : ''}
+                                <p>Consulte los logs para más detalles.</p>
+                            `;
+                    }
                 } catch (error) {
-                    document.getElementById('trainingResultContainer').style.display = 'block';
-                    document.getElementById('trainingResult').innerHTML = `Error: ${error.message}`;
                     document.getElementById('trainingResult').className = 'alert alert-danger';
+                    document.getElementById('trainingResult').innerHTML = `Error: ${error.message}`;
                 }
             });
 

--- a/test/batch-training.test.js
+++ b/test/batch-training.test.js
@@ -1,0 +1,57 @@
+const orchestratorService = require('../src/services/orchestrator.service');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('batch training session', () => {
+  beforeEach(() => {
+    axios.mockClear();
+    orchestratorService.models = {
+      test: {
+        enabled: true,
+        trainingUrl: 'http://localhost:9999/train'
+      }
+    };
+  });
+
+  afterEach(() => {
+    orchestratorService.models = {};
+    orchestratorService.finishTraining();
+  });
+
+  test('processes multiple batches without restarting', async () => {
+    axios.mockResolvedValue({ data: { expectedDischarges: 2 } });
+
+    await orchestratorService.startTrainingSession(2);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd1', signals: [{ values: [1] }], times: [0], length: 1 }
+    ]);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd2', signals: [{ values: [2] }], times: [0], length: 1 }
+    ]);
+    await new Promise(resolve => setImmediate(resolve));
+    await new Promise(resolve => setImmediate(resolve));
+
+    expect(axios).toHaveBeenCalledTimes(3);
+    expect(axios.mock.calls[0][0].url).toBe('http://localhost:9999/train');
+    expect(axios.mock.calls[1][0].url).toBe('http://localhost:9999/train/1');
+    expect(axios.mock.calls[2][0].url).toBe('http://localhost:9999/train/2');
+  });
+
+  test('retries on network error when sending discharge', async () => {
+    axios.mockResolvedValue({ data: { expectedDischarges: 1 } });
+
+    await orchestratorService.startTrainingSession(1);
+    axios.mockRejectedValueOnce(new Error('Network Error'));
+    axios.mockResolvedValueOnce({});
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd1', signals: [{ values: [1] }], times: [0], length: 1 }
+    ]);
+
+    await new Promise(resolve => setTimeout(resolve, 600));
+
+    expect(axios).toHaveBeenCalledTimes(3);
+    expect(axios.mock.calls[1][0].url).toBe('http://localhost:9999/train/1');
+    expect(axios.mock.calls[2][0].url).toBe('http://localhost:9999/train/1');
+  });
+});


### PR DESCRIPTION
## Summary
- queue training discharges per model with automatic retry
- restore dashboard loading spinner and network retry
- test batch processing and network retries

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891253bfd948328b154fc080ca2f937