### PR TITLE
feat: stream training discharges in batches

### DIFF
--- a/src/services/orchestrator.service.js
+++ b/src/services/orchestrator.service.js
@@ -13,6 +13,8 @@ class OrchestratorService {
     this.trainingTimeout = config.timeouts.training;
     // In-memory storage for training results
     this.trainingSummaries = [];
+    // Estado de entrenamiento actual para manejo por lotes
+    this.trainingSession = null;
   }
 
   /**
@@ -126,6 +128,158 @@ class OrchestratorService {
   }
 
   /**
+   * Inicia una sesión de entrenamiento con todos los modelos habilitados
+   * y almacena el estado para el envío por lotes.
+   * @param {number} totalDischarges - Total de descargas a enviar en toda la sesión
+   * @returns {Object} Resumen de los modelos que aceptaron el entrenamiento
+   */
+  async startTrainingSession(totalDischarges) {
+    const enabledModels = Object.keys(this.models)
+      .filter(model => this.models[model].enabled);
+
+    logger.info(`Enabled models for training: ${enabledModels.join(', ')}`);
+
+    if (enabledModels.length === 0) {
+      logger.error('No models are enabled');
+      throw new Error('No models are enabled for training');
+    }
+
+    const timeoutSeconds = Math.ceil(this.trainingTimeout / 1000);
+    const sessionModels = {};
+    const details = [];
+    let successful = 0;
+
+    for (const modelName of enabledModels) {
+      const modelConfig = this.models[modelName];
+      try {
+        await axios({
+          method: 'post',
+          url: modelConfig.trainingUrl,
+          data: { totalDischarges, timeoutSeconds },
+          timeout: this.trainingTimeout
+        });
+        sessionModels[modelName] = {
+          trainingUrl: modelConfig.trainingUrl,
+          queue: [],
+          sent: 0,
+          processing: false
+        };
+        details.push({ modelName, status: 'success' });
+        successful += 1;
+      } catch (error) {
+        logger.error(`Error starting training for ${modelName}: ${error.message}`);
+        details.push({ modelName, status: 'error', error: error.message });
+      }
+    }
+
+    this.trainingSession = {
+      totalDischarges,
+      sent: 0,
+      models: sessionModels
+    };
+
+    return {
+      successful,
+      failed: details.length - successful,
+      details
+    };
+  }
+
+  /**
+   * Envía un lote de descargas a los modelos dentro de la sesión activa
+   * @param {Array<Object>} rawDischarges - Descargas del lote
+   */
+  async sendTrainingBatch(rawDischarges = []) {
+    if (!this.trainingSession) {
+      throw new Error('No training session started');
+    }
+
+    const stream = this.prepareTrainingStream(rawDischarges);
+
+    for await (const discharge of stream) {
+      for (const modelName of Object.keys(this.trainingSession.models)) {
+        const copy = JSON.parse(JSON.stringify(discharge));
+        const model = this.trainingSession.models[modelName];
+        model.queue.push(copy);
+        this.processModelQueue(modelName);
+      }
+
+      // liberar memoria del discharge original
+      if (discharge.signals) {
+        for (const s of discharge.signals) {
+          s.values = null;
+        }
+        discharge.signals = null;
+      }
+      discharge.times = null;
+    }
+  }
+
+  async processModelQueue(modelName) {
+    const model = this.trainingSession.models[modelName];
+    if (!model || model.processing) return;
+    model.processing = true;
+
+    while (model.queue.length > 0) {
+      const discharge = model.queue.shift();
+      const seq = model.sent + 1;
+      await this.sendWithRetry(model.trainingUrl, seq, discharge);
+
+      if (discharge.signals) {
+        for (const s of discharge.signals) {
+          s.values = null;
+        }
+        discharge.signals = null;
+      }
+      discharge.times = null;
+
+      model.sent += 1;
+      this.updateGlobalSent();
+    }
+
+    model.processing = false;
+
+    if (this.trainingSession &&
+        this.trainingSession.sent >= this.trainingSession.totalDischarges) {
+      this.finishTraining();
+    }
+  }
+
+  async sendWithRetry(trainingUrl, seq, discharge) {
+    while (true) {
+      try {
+        await axios({
+          method: 'post',
+          url: `${trainingUrl}/${seq}`,
+          data: discharge,
+          timeout: this.trainingTimeout
+        });
+        break;
+      } catch (error) {
+        if (!error.response) {
+          logger.warn(`Network error sending batch ${seq} to ${trainingUrl}, retrying`);
+          await new Promise(resolve => setTimeout(resolve, 500));
+          continue;
+        }
+        logger.error(`Error sending batch ${seq} to ${trainingUrl}: ${error.message}`);
+        break;
+      }
+    }
+  }
+
+  updateGlobalSent() {
+    const counts = Object.values(this.trainingSession.models).map(m => m.sent);
+    this.trainingSession.sent = Math.min(...counts);
+  }
+
+  /**
+   * Finaliza la sesión de entrenamiento actual
+   */
+  finishTraining() {
+    this.trainingSession = null;
+  }
+
+  /**
    * Distribuye los datos a todos los modelos habilitados
    * @param {Object} data - Datos para la predicción (formato discharges)
    * @returns {Promise<Object>} - Resultados de todos los modelos y votación final
@@ -177,44 +331,21 @@ class OrchestratorService {
    */
   async trainModels(data) {
     logger.info('Starting training process for all models');
-    
+
     // Validar formato de datos
     if (!data.discharges || !Array.isArray(data.discharges)) {
       logger.error('Formato de datos inválido: se espera un objeto con array "discharges"');
       throw new Error('Formato de datos inválido: se espera un objeto con array "discharges"');
     }
-    
-    logger.info(`Procesando entrenamiento con ${data.discharges.length} descargas`);
-    
-    const enabledModels = Object.keys(this.models)
-      .filter(model => this.models[model].enabled);
-    
-    logger.info(`Enabled models for training: ${enabledModels.join(', ')}`);
-    
-    if (enabledModels.length === 0) {
-      logger.error('No models are enabled');
-      throw new Error('No models are enabled for training');
-    }
-    
-    const totalDischarges = data.discharges.length;
 
-    // Llamadas en paralelo a todos los modelos para entrenamiento
-    const trainingPromises = enabledModels.map(model => {
-      const stream = this.prepareTrainingStream(data.discharges);
-      return this.trainModel(model, stream, totalDischarges);
-    });
-    
-    // Esperar todas las respuestas
-    const responses = await Promise.all(trainingPromises);
-    
-    const summary = {
-      successful: responses.filter(r => r.status === 'success').length,
-      failed: responses.filter(r => r.status === 'error').length,
-      details: responses
-    };
-    
-    logger.info(`Training completed: ${summary.successful} successful, ${summary.failed} failed`);
-    
+    logger.info(`Procesando entrenamiento con ${data.discharges.length} descargas`);
+
+    const totalDischarges = data.discharges.length;
+    const summary = await this.startTrainingSession(totalDischarges);
+    await this.sendTrainingBatch(data.discharges);
+
+    logger.info('Training batches queued');
+
     return summary;
   }
 

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -2364,63 +2364,74 @@
             });
 
             // Event listener for processing discharges for training
-            document.getElementById('processDischargesBtn').addEventListener('click', function () {
-                try {
-                    const metadata = {
-                        discharges: discharges.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
-                    };
-
-                    const formData = new FormData();
-                    formData.append('metadata', JSON.stringify(metadata));
-
-                    discharges.forEach((discharge, idx) => {
-                        discharge.files.forEach(f => {
-                            formData.append(`discharge${idx}`, f.file, f.name);
+            async function sendBatchWithRetry(formData) {
+                while (true) {
+                    try {
+                        return await fetch('/api/train/raw', {
+                            method: 'POST',
+                            body: formData
                         });
-                    });
+                    } catch (err) {
+                        console.warn('Network error, retrying...', err);
+                        await new Promise(res => setTimeout(res, 500));
+                    }
+                }
+            }
 
-                    fetch('/api/train/raw', {
-                        method: 'POST',
-                        body: formData
-                    })
-                        .then(response => response.json())
-                        .then(result => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
-
-                            if (result.error) {
-                                document.getElementById('trainingResult').className = 'alert alert-danger';
-                                document.getElementById('trainingResult').innerHTML = `Error: ${result.error}`;
-                            } else {
-                                document.getElementById('trainingResult').className = 'alert alert-success';
-                                document.getElementById('trainingResult').innerHTML = `
-                                <h5>Entrenamiento iniciado</h5>
-                                <p>${result.message}</p>
-                                <p>Modelos exitosos: ${result.details.successful}</p>
-                                <p>Modelos fallidos: ${result.details.failed}</p>
-                                <p>Consulte los logs para más detalles.</p>
-                            `;
-                            }
-                        })
-                        .catch(error => {
-                            document.getElementById('trainingResultContainer').style.display = 'block';
-                            document.getElementById('trainingResult').className = 'alert alert-danger';
-                            document.getElementById('trainingResult').innerHTML = `Error sending training data: ${error.message}`;
-                        });
-
-                    document.getElementById('trainingResultContainer').style.display = 'block';
-                    document.getElementById('trainingResult').innerHTML = `
+            document.getElementById('processDischargesBtn').addEventListener('click', async function () {
+                document.getElementById('trainingResultContainer').style.display = 'block';
+                document.getElementById('trainingResult').className = 'alert';
+                document.getElementById('trainingResult').innerHTML = `
                         <div class="text-center">
                             <div class="spinner-border text-primary" role="status">
-                                <span class="visually-hidden">Loading...</span>
+                                <span class="visually-hidden">Cargando...</span>
                             </div>
-                            <p class="mt-2">Sending training data...</p>
+                            <p class="mt-2">Processing training...</p>
                         </div>
                     `;
-                    document.getElementById('trainingResult').className = 'alert';
+                try {
+                    const total = discharges.length;
+                    let firstResult = null;
+
+                    for (let start = 0; start < discharges.length; start += 10) {
+                        const batch = discharges.slice(start, start + 10);
+                        const metadata = {
+                            totalDischarges: total,
+                            discharges: batch.map(d => ({ id: d.id, anomalyTime: d.anomalyTime }))
+                        };
+
+                        const formData = new FormData();
+                        formData.append('metadata', JSON.stringify(metadata));
+
+                        batch.forEach((discharge, idx) => {
+                            discharge.files.forEach(f => {
+                                formData.append(`discharge${idx}`, f.file, f.name);
+                            });
+                        });
+
+                        const response = await sendBatchWithRetry(formData);
+                        const result = await response.json();
+                        if (!firstResult) {
+                            firstResult = result;
+                        }
+                    }
+
+                    if (firstResult && firstResult.error) {
+                        document.getElementById('trainingResult').className = 'alert alert-danger';
+                        document.getElementById('trainingResult').innerHTML = `Error: ${firstResult.error}`;
+                    } else if (firstResult) {
+                        document.getElementById('trainingResult').className = 'alert alert-success';
+                        document.getElementById('trainingResult').innerHTML = `
+                                <h5>Entrenamiento iniciado</h5>
+                                <p>${firstResult.message}</p>
+                        ${firstResult.details ? `<p>Modelos exitosos: ${firstResult.details.successful}</p>
+                                <p>Modelos fallidos: ${firstResult.details.failed}</p>` : ''}
+                                <p>Consulte los logs para más detalles.</p>
+                            `;
+                    }
                 } catch (error) {
-                    document.getElementById('trainingResultContainer').style.display = 'block';
-                    document.getElementById('trainingResult').innerHTML = `Error: ${error.message}`;
                     document.getElementById('trainingResult').className = 'alert alert-danger';
+                    document.getElementById('trainingResult').innerHTML = `Error: ${error.message}`;
                 }
             });
 

--- a/test/batch-training.test.js
+++ b/test/batch-training.test.js
@@ -1,0 +1,55 @@
+const orchestratorService = require('../src/services/orchestrator.service');
+const axios = require('axios');
+
+jest.mock('axios');
+
+describe('batch training session', () => {
+  beforeEach(() => {
+    axios.mockClear();
+    orchestratorService.models = {
+      test: {
+        enabled: true,
+        trainingUrl: 'http://localhost:9999/train'
+      }
+    };
+  });
+
+  afterEach(() => {
+    orchestratorService.models = {};
+    orchestratorService.finishTraining();
+  });
+
+  test('processes multiple batches without restarting', async () => {
+    axios.mockResolvedValue({ data: { expectedDischarges: 2 } });
+
+    await orchestratorService.startTrainingSession(2);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd1', signals: [{ values: [1] }], times: [0], length: 1 }
+    ]);
+    await new Promise(res => setImmediate(res));
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd2', signals: [{ values: [2] }], times: [0], length: 1 }
+    ]);
+    await new Promise(res => setImmediate(res));
+
+    expect(axios).toHaveBeenCalledTimes(3);
+    expect(axios.mock.calls[0][0].url).toBe('http://localhost:9999/train');
+    expect(axios.mock.calls[1][0].url).toBe('http://localhost:9999/train/1');
+    expect(axios.mock.calls[2][0].url).toBe('http://localhost:9999/train/2');
+  });
+
+  test('retries on network error', async () => {
+    axios
+      .mockResolvedValueOnce({ data: { expectedDischarges: 1 } })
+      .mockRejectedValueOnce({ message: 'NetworkError', response: null })
+      .mockResolvedValueOnce({});
+
+    await orchestratorService.startTrainingSession(1);
+    await orchestratorService.sendTrainingBatch([
+      { id: 'd1', signals: [{ values: [1] }], times: [0], length: 1 }
+    ]);
+
+    await new Promise(res => setTimeout(res, 600));
+    expect(axios).toHaveBeenCalledTimes(3); // start + retry
+  });
+});


### PR DESCRIPTION
## Summary
- enable training sessions that stream discharges in batches and free memory
- send training batches as they arrive from UI and finalize when complete
- split dashboard uploads into batches of 10 discharges
- maintain per-model training queues and retry failed requests
- restore training upload spinner and retry logic in dashboard

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6891253bfd948328b154fc080ca2f937