### PR TITLE
Stream automated test files to avoid memory overload

### DIFF
--- a/src/controllers/orchestrator.controller.js
+++ b/src/controllers/orchestrator.controller.js
@@ -3,6 +3,13 @@ const orchestratorService = require('../services/orchestrator.service');
 const logger = require('../utils/logger');
 const config = require('../config');
 const archiver = require('archiver');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+const { randomUUID } = require('crypto');
+
+// Sessions to accumulate automated prediction results without keeping everything in memory
+const automatedPredictSessions = {};
 
 /**
  * Controlador para la orquestación de modelos y predicciones
@@ -78,42 +85,24 @@ class OrchestratorController {
         }
       }
 
-      const filtered = files.filter(f => !(exclusionRegex && exclusionRegex.test(f.originalname)));
-      const results = [];
-      const stats = {};
-
-      for (const file of filtered) {
-        let data;
-        try {
-          data = JSON.parse(file.buffer.toString('utf8'));
-        } catch (e) {
-          logger.warn(`Invalid JSON in ${file.originalname}: ${e.message}`);
-          continue;
-        }
-
-        const result = await orchestratorService.orchestrate(data);
-        results.push({ file: file.originalname, result });
-
-        (result.models || []).forEach(modelResp => {
-          const name = modelResp.modelName;
-          const justification = modelResp.result && modelResp.result.justification !== undefined ?
-            modelResp.result.justification : 0;
-
-          const cfg = thresholds[name] || {};
-          const justThresh = parseFloat(cfg.justification) || 0;
-          const countThresh = parseInt(cfg.count) || 1;
-
-          if (!stats[name]) {
-            stats[name] = { rows: [], passes: [], count: countThresh };
-          }
-
-          const pass = justification > justThresh ? 1 : 0;
-          stats[name].passes.push(pass);
-          const history = stats[name].passes;
-          const countPass = history.length >= countThresh && history.slice(-countThresh).every(v => v === 1) ? 1 : 0;
-          stats[name].rows.push({ justification, justification_threshold: pass, count_threshold: countPass });
-        });
+      const groupPattern = req.body.groupPattern || '(.*)';
+      let groupRegex;
+      try {
+        groupRegex = new RegExp(groupPattern);
+      } catch (e) {
+        return res.status(StatusCodes.BAD_REQUEST).json({ error: 'Invalid grouping pattern' });
       }
+
+      const filtered = files.filter(f => !(exclusionRegex && exclusionRegex.test(f.originalname)));
+      const groups = {};
+      filtered.forEach(f => {
+        const match = f.originalname.match(groupRegex);
+        const key = match ? (match[1] || match[0]) : f.originalname;
+        if (!groups[key]) groups[key] = [];
+        groups[key].push(f);
+      });
+
+      const stats = {};
 
       res.set('Content-Type', 'application/zip');
       res.set('Content-Disposition', 'attachment; filename="automated_predicts.zip"');
@@ -122,13 +111,87 @@ class OrchestratorController {
       archive.on('error', err => { throw err; });
       archive.pipe(res);
 
-      results.forEach(r => {
-        archive.append(JSON.stringify(r.result, null, 2), { name: `raw/${r.file}` });
-      });
+      for (const [key, groupFiles] of Object.entries(groups)) {
+        const fileData = [];
+        for (const file of groupFiles) {
+          try {
+            const content = await fs.promises.readFile(file.path, 'utf8');
+            fileData.push({ name: file.originalname, content });
+          } finally {
+            fs.unlink(file.path, () => {});
+          }
+        }
+
+        const { signals, times, length } = orchestratorService.parseSensorFiles(fileData);
+        const discharge = { id: key, signals, times, length };
+
+        const result = await orchestratorService.orchestrate({ discharges: [discharge] });
+        const safeName = key.replace(/[^a-zA-Z0-9_-]/g, '_');
+        archive.append(JSON.stringify(result, null, 2), { name: `raw/${safeName}.json` });
+
+        (result.models || []).forEach(modelResp => {
+          const name = modelResp.modelName;
+          const cfg = thresholds[name] || {};
+          const justThresh = parseFloat(cfg.justification) || 0;
+          const countThresh = parseInt(cfg.count) || 1;
+
+          const rawJust = modelResp.result && modelResp.result.justification;
+          const justArray = Array.isArray(rawJust)
+            ? rawJust.map(v => parseFloat(v))
+            : rawJust !== undefined && rawJust !== null
+              ? [parseFloat(rawJust)]
+              : [];
+
+          if (!stats[name]) {
+            stats[name] = { discharges: {}, dischargeIds: [], count: countThresh };
+          }
+          if (!stats[name].discharges[key]) {
+            stats[name].discharges[key] = { justifications: [], thresholds: [], count_thresholds: [] };
+            stats[name].dischargeIds.push(key);
+          }
+
+          const dStats = stats[name].discharges[key];
+          justArray.forEach(justification => {
+            const pass = justification > justThresh ? 1 : 0;
+            dStats.justifications.push(justification);
+            dStats.thresholds.push(pass);
+            const history = dStats.thresholds;
+            const countPass =
+              history.length >= countThresh && history.slice(-countThresh).every(v => v === 1) ? 1 : 0;
+            dStats.count_thresholds.push(countPass);
+          });
+        });
+      }
 
       Object.entries(stats).forEach(([model, data]) => {
-        let csv = 'justification,justification_threshold,count_threshold\n';
-        csv += data.rows.map(row => `${row.justification},${row.justification_threshold},${row.count_threshold}`).join('\n');
+        const headers = [];
+        data.dischargeIds.forEach(id => {
+          const safeId = id.replace(/[^a-zA-Z0-9_-]/g, '_');
+          headers.push(
+            `${safeId}_justification`,
+            `${safeId}_justification_threshold`,
+            `${safeId}_count_threshold`
+          );
+        });
+
+        const maxRows = Math.max(
+          0,
+          ...data.dischargeIds.map(id => data.discharges[id].justifications.length)
+        );
+        const rows = [];
+        for (let i = 0; i < maxRows; i++) {
+          const row = [];
+          data.dischargeIds.forEach(id => {
+            const d = data.discharges[id];
+            row.push(
+              d.justifications[i] !== undefined ? d.justifications[i] : '',
+              d.thresholds[i] !== undefined ? d.thresholds[i] : '',
+              d.count_thresholds[i] !== undefined ? d.count_thresholds[i] : ''
+            );
+          });
+          rows.push(row.join(','));
+        }
+        const csv = `${headers.join(',')}\n${rows.join('\n')}`;
         archive.append(csv, { name: `stats/${model}.csv` });
       });
 
@@ -140,6 +203,165 @@ class OrchestratorController {
         message: error.message
       });
     }
+  }
+
+  /**
+   * Start a session for sequential automated predictions
+   * @param {Request} _req
+   * @param {Response} res
+   */
+  startAutomatedPredictsSession(_req, res) {
+    const id = randomUUID();
+    const dir = path.join(os.tmpdir(), `automated_predicts_${id}`);
+    fs.mkdirSync(path.join(dir, 'raw'), { recursive: true });
+    automatedPredictSessions[id] = { dir, stats: {} };
+    res.json({ sessionId: id });
+  }
+
+  /**
+   * Process a batch of prediction files for a session
+   * @param {Request} req
+   * @param {Response} res
+   */
+  async uploadAutomatedPredict(req, res) {
+    const { sessionId } = req.params;
+    const session = automatedPredictSessions[sessionId];
+    if (!session) {
+      return res.status(StatusCodes.BAD_REQUEST).json({ error: 'Invalid session' });
+    }
+
+    const files = req.files || [];
+    if (!files.length) {
+      return res.status(StatusCodes.BAD_REQUEST).json({ error: 'No prediction files uploaded' });
+    }
+
+    const thresholds = req.body.thresholds ? JSON.parse(req.body.thresholds) : {};
+    const dischargeId = req.body.dischargeId || files[0].originalname;
+
+    try {
+      const fileData = [];
+      for (const f of files) {
+        try {
+          const content = await fs.promises.readFile(f.path, 'utf8');
+          fileData.push({ name: f.originalname, content });
+        } finally {
+          fs.unlink(f.path, () => {});
+        }
+      }
+
+      const { signals, times, length } = orchestratorService.parseSensorFiles(fileData);
+      const discharge = { id: dischargeId, signals, times, length };
+
+      const result = await orchestratorService.orchestrate({ discharges: [discharge] });
+
+      const rawDir = path.join(session.dir, 'raw');
+      const safeName = dischargeId.replace(/[^a-zA-Z0-9_-]/g, '_');
+      await fs.promises.writeFile(path.join(rawDir, `${safeName}.json`), JSON.stringify(result, null, 2));
+
+      (result.models || []).forEach(modelResp => {
+        const name = modelResp.modelName;
+        const cfg = thresholds[name] || {};
+        const justThresh = parseFloat(cfg.justification) || 0;
+        const countThresh = parseInt(cfg.count) || 1;
+
+        const rawJust = modelResp.result && modelResp.result.justification;
+        const justArray = Array.isArray(rawJust)
+          ? rawJust.map(v => parseFloat(v))
+          : rawJust !== undefined && rawJust !== null
+            ? [parseFloat(rawJust)]
+            : [];
+
+        if (!session.stats[name]) {
+          session.stats[name] = { discharges: {}, dischargeIds: [], count: countThresh };
+        }
+        if (!session.stats[name].discharges[dischargeId]) {
+          session.stats[name].discharges[dischargeId] = { justifications: [], thresholds: [], count_thresholds: [] };
+          session.stats[name].dischargeIds.push(dischargeId);
+        }
+
+        const dStats = session.stats[name].discharges[dischargeId];
+        justArray.forEach(justification => {
+          const pass = justification > justThresh ? 1 : 0;
+          dStats.justifications.push(justification);
+          dStats.thresholds.push(pass);
+          const history = dStats.thresholds;
+          const countPass =
+            history.length >= countThresh && history.slice(-countThresh).every(v => v === 1) ? 1 : 0;
+          dStats.count_thresholds.push(countPass);
+        });
+      });
+
+      res.json({ ok: true });
+    } catch (error) {
+      logger.warn(`Error processing discharge ${dischargeId}: ${error.message}`);
+      return res.status(StatusCodes.BAD_REQUEST).json({
+        error: 'Invalid prediction files',
+        message: error.message
+      });
+    }
+  }
+
+  /**
+   * Finalize session and send ZIP with accumulated results
+   * @param {Request} req
+   * @param {Response} res
+   */
+  async finalizeAutomatedPredicts(req, res) {
+    const { sessionId } = req.params;
+    const session = automatedPredictSessions[sessionId];
+    if (!session) {
+      return res.status(StatusCodes.BAD_REQUEST).json({ error: 'Invalid session' });
+    }
+
+    res.set('Content-Type', 'application/zip');
+    res.set('Content-Disposition', 'attachment; filename="automated_predicts.zip"');
+
+    const archive = archiver('zip');
+    archive.on('error', err => { throw err; });
+    archive.pipe(res);
+
+    const rawDir = path.join(session.dir, 'raw');
+    for (const file of await fs.promises.readdir(rawDir)) {
+      archive.file(path.join(rawDir, file), { name: `raw/${file}` });
+    }
+
+    Object.entries(session.stats).forEach(([model, data]) => {
+      const headers = [];
+      data.dischargeIds.forEach(id => {
+        const safeId = id.replace(/[^a-zA-Z0-9_-]/g, '_');
+        headers.push(
+          `${safeId}_justification`,
+          `${safeId}_justification_threshold`,
+          `${safeId}_count_threshold`
+        );
+      });
+
+      const maxRows = Math.max(
+        0,
+        ...data.dischargeIds.map(id => data.discharges[id].justifications.length)
+      );
+      const rows = [];
+      for (let i = 0; i < maxRows; i++) {
+        const row = [];
+        data.dischargeIds.forEach(id => {
+          const d = data.discharges[id];
+          row.push(
+            d.justifications[i] !== undefined ? d.justifications[i] : '',
+            d.thresholds[i] !== undefined ? d.thresholds[i] : '',
+            d.count_thresholds[i] !== undefined ? d.count_thresholds[i] : ''
+          );
+        });
+        rows.push(row.join(','));
+      }
+      const csv = `${headers.join(',')}\n${rows.join('\n')}`;
+      archive.append(csv, { name: `stats/${model}.csv` });
+    });
+
+    await archive.finalize();
+
+    // Cleanup
+    fs.rm(session.dir, { recursive: true, force: true }, () => {});
+    delete automatedPredictSessions[sessionId];
   }
 
   /**

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -10,7 +10,6 @@ const router = express.Router();
 
 // Ruta para realizar predicciones
 router.post('/predict', validatedischargealData, orchestratorController.predict);
-router.post('/automated-predicts', diskUpload.any(), orchestratorController.automatedPredicts);
 router.post('/automated-predicts/session', orchestratorController.startAutomatedPredictsSession);
 router.post('/automated-predicts/session/:sessionId', diskUpload.any(), orchestratorController.uploadAutomatedPredict);
 router.get('/automated-predicts/session/:sessionId/zip', orchestratorController.finalizeAutomatedPredicts);

--- a/src/routes/index.js
+++ b/src/routes/index.js
@@ -1,18 +1,23 @@
 const express = require('express');
 const multer = require('multer');
+const os = require('os');
 const orchestratorController = require('../controllers/orchestrator.controller');
 const { validatedischargealData, validateModelConfig } = require('../middleware/validation.middleware');
 
-const upload = multer();
+const memoryUpload = multer();
+const diskUpload = multer({ dest: os.tmpdir() });
 const router = express.Router();
 
 // Ruta para realizar predicciones
 router.post('/predict', validatedischargealData, orchestratorController.predict);
-router.post('/automated-predicts', upload.any(), orchestratorController.automatedPredicts);
+router.post('/automated-predicts', diskUpload.any(), orchestratorController.automatedPredicts);
+router.post('/automated-predicts/session', orchestratorController.startAutomatedPredictsSession);
+router.post('/automated-predicts/session/:sessionId', diskUpload.any(), orchestratorController.uploadAutomatedPredict);
+router.get('/automated-predicts/session/:sessionId/zip', orchestratorController.finalizeAutomatedPredicts);
 
 // Ruta para entrenamiento de modelos
 router.post('/train', validatedischargealData, orchestratorController.train);
-router.post('/train/raw', upload.any(), orchestratorController.trainRaw);
+router.post('/train/raw', memoryUpload.any(), orchestratorController.trainRaw);
 router.post('/trainingCompleted', orchestratorController.trainingCompleted);
 
 // Ruta para verificar la salud de los servicios

--- a/src/services/orchestrator.service.js
+++ b/src/services/orchestrator.service.js
@@ -352,9 +352,9 @@ class OrchestratorService {
       logger.error('Formato de datos inválido: se espera un objeto con array "discharges"');
       throw new Error('Formato de datos inválido: se espera un objeto con array "discharges"');
     }
-    
-    logger.info(`Procesando predicción con ${data.discharges.length} descargas`);
-    
+
+    logger.info(`Processing predictions with ${data.discharges.length} discharges`);
+
     const enabledModels = Object.keys(this.models)
       .filter(model => this.models[model].enabled);
     

--- a/src/views/dashboard.ejs
+++ b/src/views/dashboard.ejs
@@ -540,6 +540,13 @@
             </div>
         </header>
 
+        <div id="automatedPredictProgressContainer" class="mb-3" style="display:none;">
+            <div class="progress">
+                <div id="automatedPredictProgressBar" class="progress-bar" role="progressbar" style="width: 0%;" aria-valuemin="0" aria-valuemax="100"></div>
+            </div>
+            <div id="automatedPredictGroupInfo" class="mt-2 text-center"></div>
+        </div>
+
         <div class="row mb-4">
             <div class="col-12">
                 <div class="card">
@@ -1158,6 +1165,10 @@
                                 <strong>Files Selected:</strong>
                                 <span id="automatedFilesCount" class="file-count-preview">0 files</span>
                             </div>
+                            <div class="d-flex justify-content-between align-items-center mb-2">
+                                <strong>Groups Detected:</strong>
+                                <span id="automatedGroupCount" class="file-count-preview">0 groups</span>
+                            </div>
                             <div id="automatedFilesList" style="max-height:150px; overflow-y:auto;"></div>
                         </div>
                     </div>
@@ -1607,16 +1618,59 @@
             if (automatedFiles.length === 0) {
                 preview.style.display = 'none';
                 document.getElementById('automatedPredictsApplyBtn').disabled = true;
+                document.getElementById('automatedGroupCount').textContent = '0 groups';
                 return;
             }
             count.textContent = `${automatedFiles.length} files`;
             list.innerHTML = automatedFiles.map(f => `<div class="small text-muted">${f.name}</div>`).join('');
             preview.style.display = 'block';
-            document.getElementById('automatedPredictsApplyBtn').disabled = false;
+            updateAutomatedGroupsInfo();
+        }
+
+        function updateAutomatedGroupsInfo() {
+            const groupCountEl = document.getElementById('automatedGroupCount');
+            const applyBtn = document.getElementById('automatedPredictsApplyBtn');
+            if (automatedFiles.length === 0) {
+                groupCountEl.textContent = '0 groups';
+                applyBtn.disabled = true;
+                return;
+            }
+
+            const exclusionPattern = document.getElementById('automatedExclusionPattern').value.trim();
+            let exclusionRegex = null;
+            if (exclusionPattern) {
+                try { exclusionRegex = new RegExp(exclusionPattern, 'i'); } catch (e) {}
+            }
+            const groupPattern = document.getElementById('automatedGroupPattern').value.trim() || '(.*)';
+            let groupRegex;
+            try { groupRegex = new RegExp(groupPattern); } catch (e) {
+                groupCountEl.textContent = '0 groups';
+                applyBtn.disabled = true;
+                return;
+            }
+            const groups = {};
+            automatedFiles.forEach(f => {
+                if (exclusionRegex && exclusionRegex.test(f.name)) return;
+                const match = f.name.match(groupRegex);
+                const key = match ? (match[1] || match[0]) : f.name;
+                if (!groups[key]) groups[key] = [];
+                groups[key].push(f);
+            });
+            const groupCount = Object.keys(groups).length;
+            groupCountEl.textContent = `${groupCount} group${groupCount !== 1 ? 's' : ''}`;
+            applyBtn.disabled = groupCount === 0;
         }
 
         async function applyAutomatedPredicts() {
             const exclusionPattern = document.getElementById('automatedExclusionPattern').value.trim();
+            let exclusionRegex = null;
+            if (exclusionPattern) {
+                try { exclusionRegex = new RegExp(exclusionPattern, 'i'); } catch (e) {}
+            }
+            const groupPattern = document.getElementById('automatedGroupPattern').value.trim() || '(.*)';
+            let groupRegex;
+            try { groupRegex = new RegExp(groupPattern); } catch (e) { alert('Invalid grouping pattern'); return; }
+
             const thresholds = {};
             document.querySelectorAll('#automatedModelThresholds .justification-threshold').forEach(input => {
                 const model = input.dataset.model;
@@ -1627,15 +1681,52 @@
                 };
             });
 
-            const formData = new FormData();
-            automatedFiles.forEach(f => formData.append('files', f, f.name));
-            formData.append('exclusionPattern', exclusionPattern);
-            formData.append('thresholds', JSON.stringify(thresholds));
+            const sessionResp = await fetch('/api/automated-predicts/session', { method: 'POST' });
+            const { sessionId } = await sessionResp.json();
 
-            const response = await fetch('/api/automated-predicts', {
-                method: 'POST',
-                body: formData
+            const groups = {};
+            automatedFiles.forEach(f => {
+                if (exclusionRegex && exclusionRegex.test(f.name)) return;
+                const match = f.name.match(groupRegex);
+                const key = match ? (match[1] || match[0]) : f.name;
+                if (!groups[key]) groups[key] = [];
+                groups[key].push(f);
             });
+
+            const groupEntries = Object.entries(groups);
+            const totalGroups = groupEntries.length;
+            if (totalGroups === 0) {
+                alert('No files to process.');
+                return;
+            }
+
+            automatedPredictsModal.hide();
+            const progressContainer = document.getElementById('automatedPredictProgressContainer');
+            const progressBar = document.getElementById('automatedPredictProgressBar');
+            const progressText = document.getElementById('automatedPredictGroupInfo');
+            progressContainer.style.display = 'block';
+            progressBar.style.width = '0%';
+            progressBar.setAttribute('aria-valuenow', '0');
+            progressText.textContent = `Processing 0 of ${totalGroups} group(s)...`;
+
+            let processed = 0;
+            for (const [key, files] of groupEntries) {
+                const formData = new FormData();
+                files.forEach(f => formData.append('files', f, f.name));
+                formData.append('dischargeId', key);
+                formData.append('thresholds', JSON.stringify(thresholds));
+                await fetch(`/api/automated-predicts/session/${sessionId}`, {
+                    method: 'POST',
+                    body: formData
+                });
+                processed++;
+                const percent = Math.round((processed / totalGroups) * 100);
+                progressBar.style.width = `${percent}%`;
+                progressBar.setAttribute('aria-valuenow', String(percent));
+                progressText.textContent = `Processing ${processed} of ${totalGroups} group(s)...`;
+            }
+
+            const response = await fetch(`/api/automated-predicts/session/${sessionId}/zip`);
             if (!response.ok) {
                 try {
                     const err = await response.json();
@@ -1643,6 +1734,7 @@
                 } catch {
                     alert('Error processing predictions');
                 }
+                progressContainer.style.display = 'none';
                 return;
             }
             const blob = await response.blob();
@@ -1654,7 +1746,7 @@
             a.click();
             a.remove();
             URL.revokeObjectURL(url);
-            automatedPredictsModal.hide();
+            progressContainer.style.display = 'none';
         }
 
         // Multiple Discharges Functions
@@ -2498,6 +2590,8 @@
             // Automated predicts events
             document.getElementById('automatedPredictsBtn').addEventListener('click', showAutomatedPredictsModal);
             document.getElementById('automatedPredictsFolder').addEventListener('change', handleAutomatedFolderChange);
+            document.getElementById('automatedGroupPattern').addEventListener('input', updateAutomatedGroupsInfo);
+            document.getElementById('automatedExclusionPattern').addEventListener('input', updateAutomatedGroupsInfo);
             document.getElementById('automatedPredictsApplyBtn').addEventListener('click', applyAutomatedPredicts);
 
             // Event listener for the toggle preview button


### PR DESCRIPTION
## Summary
- Group automated prediction files by regex on the backend and process each group as a discharge
- Allow session uploads to send multiple files per discharge and persist results per discharge
- Group files on the dashboard before sequentially uploading them for prediction
- Show grouped discharge count and progress bar for automated prediction uploads
- Parse grouped files into sensor signals so only one prediction request is sent per discharge group
- Stream automated test files to avoid memory overload
- Record per-discharge statistics per model, storing justification and threshold flags under discharge identifiers
- Track every justification window per discharge and write multi-row stats CSVs

## Testing
- `npm test`
- `npm run lint` *(fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)*

------
https://chatgpt.com/codex/tasks/task_e_689355bb92808328b4fd1ea3efcea9ae